### PR TITLE
Depend on gumbo-parser@0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gumbo-parser": "~0.1.3",
+    "gumbo-parser": "0.2.2",
     "zest.js": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
gumbo-parser gained support for Node 4.x.x in 0.2.2 version.
Older versions fail to compile with that Node version.