### PR TITLE
Topic/create element node type

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -17,7 +17,7 @@ exports = module.exports = Element;
  */
 
 function Element(options) {
-  Node.call(this, options);
+  Node.call(this, Object.assign({nodeType: 1}, options));
   this.attributes = [];
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -104,6 +104,24 @@ describe('document', function(){
     assert(elem.attributes[0].name === "id");
     assert(elem.attributes[0].value === "hello");
   });
+
+  it('should set nodeType on createElement', function(){
+    var d = dom('<html><div id="hello"></div></html>');
+    var elem = d.document.createElement("div");
+    assert(elem.nodeType == 1);
+  });
+
+  it('should set tagName on createElement', function(){
+    var d = dom('<html><div id="hello"></div></html>');
+    var elem = d.document.createElement("div");
+    assert(elem.tagName == "div");
+  });
+
+  it('should set nodeName on createElement', function(){
+    var d = dom('<html><div id="hello"></div></html>');
+    var elem = d.document.createElement("div");
+    assert(elem.nodeName == elem.tagName);
+  });
 });
 
 describe('serialize', function(){


### PR DESCRIPTION
Element constructor sets the node type to 1, as per [DOM specification](https://www.w3.org/TR/dom/#dom-node-nodetype).